### PR TITLE
Potential fix for code scanning alert no. 229: Uncontrolled command line

### DIFF
--- a/crypto/func/auto-tests/legacy_tester.py
+++ b/crypto/func/auto-tests/legacy_tester.py
@@ -49,8 +49,22 @@ def getenv(name, default=None):
         exit(1)
     return default
 
-FUNC_EXECUTABLE = getenv("FUNC_EXECUTABLE", "func")
-FIFT_EXECUTABLE = getenv("FIFT_EXECUTABLE", "fift")
+def _validate_executable_name(name, var_name):
+    """
+    Ensure the executable name taken from the environment is a simple command
+    name without any path separators. This prevents unintended execution of
+    arbitrary paths while still allowing selecting alternate binaries on PATH.
+    """
+    # Disallow empty names and any path separators.
+    if not name or os.path.sep in name or (os.path.altsep and os.path.altsep in name):
+        raise ValueError(
+            "Invalid value for {var}: {val!r}. Expected a simple executable name "
+            "without path separators.".format(var=var_name, val=name)
+        )
+    return name
+
+FUNC_EXECUTABLE = _validate_executable_name(getenv("FUNC_EXECUTABLE", "func"), "FUNC_EXECUTABLE")
+FIFT_EXECUTABLE = _validate_executable_name(getenv("FIFT_EXECUTABLE", "fift"), "FIFT_EXECUTABLE")
 TMP_DIR = tempfile.mkdtemp()
 
 COMPILED_FIF = os.path.join(TMP_DIR, "compiled.fif")


### PR DESCRIPTION
Potential fix for [https://github.com/triple-labs/ton/security/code-scanning/229](https://github.com/triple-labs/ton/security/code-scanning/229)

In general, to fix uncontrolled command-line execution when reading a command from the environment, we should restrict the possible values: either use fixed string literals, or validate user-provided paths/commands against an allowlist or basic safety rules (e.g., ensure they are simple basenames without path separators and not empty). For this script, the intended behavior is to allow override of the default compiler/interpreter names while not allowing arbitrary shell injection or unsafe path strings.

Best minimal fix here:
- Keep the existing `getenv` helper but add a small wrapper that validates `FUNC_EXECUTABLE` and `FIFT_EXECUTABLE` before use.
- Constrain these environment-provided values to *simple command names* (no path separators). That still lets users select an alternative `fift`/`func` on their `PATH` (e.g., `my-fift`) but avoids accidental or malicious injection of arbitrary paths or shell metacharacters.
- Perform this validation once, right after reading the environment, and raise a clear `ValueError` if the environment is unsafe. This ensures that the later `subprocess.run([FIFT_EXECUTABLE, ...])` calls only ever use validated values.
- This requires adding a small helper function (e.g., `def _validate_executable_name(name, var_name): ...`) and using it when assigning `FUNC_EXECUTABLE` and `FIFT_EXECUTABLE`.

Concretely:
- In `crypto/func/auto-tests/legacy_tester.py`, directly after `getenv` define `_validate_executable_name`.
- Modify the assignments to `FUNC_EXECUTABLE` and `FIFT_EXECUTABLE` to call this validator on the raw environment values.
- Leave the rest of the code (including how `subprocess.run` is called) unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
